### PR TITLE
Feature/973 Sending Required Allowance Holdings Parameters

### DIFF
--- a/src/allowance/allowance-holding-dim.repository.spec.ts
+++ b/src/allowance/allowance-holding-dim.repository.spec.ts
@@ -1,0 +1,58 @@
+import { Test } from '@nestjs/testing';
+import { SelectQueryBuilder } from 'typeorm';
+
+import { AllowanceHoldingsParamsDTO } from '../dto/allowance-holdings.params.dto';
+import { AllowanceHoldingDimRepository } from './allowance-holding-dim.repository';
+import { AllowanceHoldingDim } from '../entities/allowance-holding-dim.entity';
+
+const mockQueryBuilder = () => ({
+  andWhere: jest.fn(),
+  getMany: jest.fn(),
+  select: jest.fn(),
+  innerJoin: jest.fn(),
+});
+
+let filters: AllowanceHoldingsParamsDTO = {
+  vintageBeginYear: 2019,
+  vintageEndYear: 2019,
+};
+
+describe('-- AllowanceHoldingDimRepository --', () => {
+  let allowanceHoldingDimRepository;
+  let queryBuilder;
+
+  beforeEach(async () => {
+    const module = await Test.createTestingModule({
+      providers: [
+        AllowanceHoldingDimRepository,
+        { provide: SelectQueryBuilder, useFactory: mockQueryBuilder },
+      ],
+    }).compile();
+
+    allowanceHoldingDimRepository = module.get<AllowanceHoldingDimRepository>(
+      AllowanceHoldingDimRepository,
+    );
+    queryBuilder = module.get<SelectQueryBuilder<AllowanceHoldingDim>>(
+      SelectQueryBuilder,
+    );
+
+    allowanceHoldingDimRepository.createQueryBuilder = jest
+      .fn()
+      .mockReturnValue(queryBuilder);
+    queryBuilder.select.mockReturnValue(queryBuilder);
+    queryBuilder.innerJoin.mockReturnValue(queryBuilder);
+    queryBuilder.andWhere.mockReturnValue(queryBuilder);
+    queryBuilder.getMany.mockReturnValue('mockAllowanceHoldings');
+  });
+
+  describe('getAllowanceHoldings', () => {
+    it('calls createQueryBuilder and gets all AllowanceHoldingDim values from the repository', async () => {
+      let result = await allowanceHoldingDimRepository.getAllowanceHoldings(
+        filters,
+      );
+
+      expect(queryBuilder.getMany).toHaveBeenCalled();
+      expect(result).toEqual('mockAllowanceHoldings');
+    });
+  });
+});

--- a/src/allowance/allowance-holding-dim.repository.ts
+++ b/src/allowance/allowance-holding-dim.repository.ts
@@ -1,0 +1,40 @@
+import { EntityRepository, Repository } from 'typeorm';
+
+import { AllowanceHoldingDim } from '../entities/allowance-holding-dim.entity';
+import { AllowanceHoldingsParamsDTO } from '../dto/allowance-holdings.params.dto';
+import { QueryBuilderHelper } from '../utils/query-builder.helper';
+
+@EntityRepository(AllowanceHoldingDim)
+export class AllowanceHoldingDimRepository extends Repository<
+  AllowanceHoldingDim
+> {
+  async getAllowanceHoldings(
+    allowanceHoldingsParamsDTO: AllowanceHoldingsParamsDTO,
+  ): Promise<AllowanceHoldingDim[]> {
+    let query = this.createQueryBuilder('ahd')
+      .select([
+        'ahd.accountNumber',
+        'ahd.accountName',
+        'ahd.prgCode',
+        'ahd.vintageYear',
+        'ahd.totalBlock',
+        'ahd.startBlock',
+        'ahd.endBlock',
+        'af.orisCode',
+        'af.state',
+        'af.epaRegion',
+        'af.ownDisplay',
+        'af.accountType',
+      ])
+      .innerJoin('ahd.accountFact', 'af');
+    query = QueryBuilderHelper.createAllowanceQuery(
+      query,
+      allowanceHoldingsParamsDTO,
+      ['vintageBeginYear', 'vintageEndYear'],
+      'ahd',
+      'af',
+    );
+
+    return query.getMany();
+  }
+}

--- a/src/allowance/allowance.controller.spec.ts
+++ b/src/allowance/allowance.controller.spec.ts
@@ -1,10 +1,11 @@
-import { ConfigModule } from '@nestjs/config';
 import { Test } from '@nestjs/testing';
 
-import appConfig from '../config/app.config';
-import dbConfig from '../config/db.config';
 import { AllowanceController } from './allowance.controller';
 import { AllowanceService } from './allowance.service';
+import { AllowanceHoldingsMap } from '../maps/allowance-holdings.map';
+import { AllowanceHoldingDimRepository } from './allowance-holding-dim.repository';
+import { AllowanceHoldingsDTO } from '../dto/allowance-holdings.dto';
+import { AllowanceHoldingsParamsDTO } from '../dto/allowance-holdings.params.dto';
 
 describe('-- Allowance Controller --', () => {
   let allowanceController: AllowanceController;
@@ -12,37 +13,40 @@ describe('-- Allowance Controller --', () => {
 
   beforeEach(async () => {
     const module = await Test.createTestingModule({
-      imports: [
-        ConfigModule.forRoot({
-          isGlobal: true,
-          load: [dbConfig, appConfig],
-        }),
-      ],
       controllers: [AllowanceController],
-      providers: [AllowanceService],
+      providers: [
+        AllowanceService,
+        AllowanceHoldingsMap,
+        AllowanceHoldingDimRepository,
+      ],
     }).compile();
 
     allowanceController = module.get(AllowanceController);
     allowanceService = module.get(AllowanceService);
-
-    allowanceService.getAllowanceHoldings = jest
-      .fn()
-      .mockReturnValue('Hello allowanceHoldings');
 
     allowanceService.getAllowanceTransactions = jest
       .fn()
       .mockReturnValue('Hello allowanceTransactions');
   });
 
-  describe('getAllowanceHoldings', () => {
-    it('should return "Hello allowanceHoldings"', () => {
-      expect(allowanceController.getAllowanceHoldings()).toBe(
-        'Hello allowanceHoldings',
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  describe('* getAllowanceHoldings', () => {
+    it('should call the service and return allowance holdings ', async () => {
+      const expectedResults: AllowanceHoldingsDTO[] = [];
+      const paramsDTO = new AllowanceHoldingsParamsDTO();
+      jest
+        .spyOn(allowanceService, 'getAllowanceHoldings')
+        .mockResolvedValue(expectedResults);
+      expect(await allowanceController.getAllowanceHoldings(paramsDTO)).toBe(
+        expectedResults,
       );
     });
   });
 
-  describe('getAllowanceTransactions', () => {
+  describe('* getAllowanceTransactions', () => {
     it('should return "Hello allowanceTransactions"', () => {
       expect(allowanceController.getAllowanceTransactions()).toBe(
         'Hello allowanceTransactions',

--- a/src/allowance/allowance.controller.ts
+++ b/src/allowance/allowance.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get } from '@nestjs/common';
+import { Controller, Get, Query } from '@nestjs/common';
 import {
   ApiBadRequestResponse,
   ApiNotFoundResponse,
@@ -7,6 +7,8 @@ import {
 } from '@nestjs/swagger';
 
 import { AllowanceService } from './allowance.service';
+import { AllowanceHoldingsParamsDTO } from '../dto/allowance-holdings.params.dto';
+import { AllowanceHoldingsDTO } from '../dto/allowance-holdings.dto';
 
 @ApiTags('Allowance')
 @Controller()
@@ -23,8 +25,12 @@ export class AllowanceController {
   @ApiNotFoundResponse({
     description: 'Resource Not Found',
   })
-  getAllowanceHoldings(): string {
-    return this.allowanceService.getAllowanceHoldings();
+  getAllowanceHoldings(
+    @Query() allowanceHoldingsParamsDTO: AllowanceHoldingsParamsDTO,
+  ): Promise<AllowanceHoldingsDTO[]> {
+    return this.allowanceService.getAllowanceHoldings(
+      allowanceHoldingsParamsDTO,
+    );
   }
 
   @Get('/transactions')

--- a/src/allowance/allowance.module.ts
+++ b/src/allowance/allowance.module.ts
@@ -1,10 +1,14 @@
 import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
 
 import { AllowanceController } from './allowance.controller';
 import { AllowanceService } from './allowance.service';
+import { AllowanceHoldingDimRepository } from './allowance-holding-dim.repository';
+import { AllowanceHoldingsMap } from '../maps/allowance-holdings.map';
 
 @Module({
+  imports: [TypeOrmModule.forFeature([AllowanceHoldingDimRepository])],
   controllers: [AllowanceController],
-  providers: [AllowanceService],
+  providers: [AllowanceHoldingsMap, AllowanceService],
 })
 export class AllowanceModule {}

--- a/src/allowance/allowance.service.spec.ts
+++ b/src/allowance/allowance.service.spec.ts
@@ -1,32 +1,52 @@
-import { ConfigModule } from '@nestjs/config';
 import { Test } from '@nestjs/testing';
 
-import appConfig from '../config/app.config';
-import dbConfig from '../config/db.config';
 import { AllowanceService } from './allowance.service';
+import { AllowanceHoldingDimRepository } from './allowance-holding-dim.repository';
+import { AllowanceHoldingsMap } from '../maps/allowance-holdings.map';
+import { AllowanceHoldingsParamsDTO } from '../dto/allowance-holdings.params.dto';
+
+const mockAllowanceHoldingDimRepository = () => ({
+  getAllowanceHoldings: jest.fn(),
+});
+
+const mockAllowanceHoldingsMap = () => ({
+  many: jest.fn(),
+});
 
 describe('-- Allowance Service --', () => {
   let allowanceService;
+  let allowanceHoldingDimRepository;
+  let allowanceHoldingsMap;
 
   beforeEach(async () => {
     const module = await Test.createTestingModule({
-      imports: [
-        ConfigModule.forRoot({
-          isGlobal: true,
-          load: [dbConfig, appConfig],
-        }),
+      providers: [
+        AllowanceService,
+        {
+          provide: AllowanceHoldingDimRepository,
+          useFactory: mockAllowanceHoldingDimRepository,
+        },
+        { provide: AllowanceHoldingsMap, useFactory: mockAllowanceHoldingsMap },
       ],
-      providers: [AllowanceService],
     }).compile();
 
     allowanceService = module.get(AllowanceService);
+    allowanceHoldingDimRepository = module.get(AllowanceHoldingDimRepository);
+    allowanceHoldingsMap = module.get(AllowanceHoldingsMap);
   });
 
   describe('getAllowanceHoldings', () => {
-    it('should return "Hello allowanceHoldings"', async () => {
-      expect(allowanceService.getAllowanceHoldings()).toBe(
-        'Hello allowanceHoldings',
+    it('calls AllowanceHoldingDimRepository.getAllowanceHoldings() and gets all allowance holdings from the repository', async () => {
+      allowanceHoldingDimRepository.getAllowanceHoldings.mockResolvedValue(
+        'list of allowance holdings',
       );
+      allowanceHoldingsMap.many.mockReturnValue('mapped DTOs');
+
+      let filters = new AllowanceHoldingsParamsDTO();
+
+      let result = await allowanceService.getAllowanceHoldings(filters);
+      expect(allowanceHoldingsMap.many).toHaveBeenCalled();
+      expect(result).toEqual('mapped DTOs');
     });
   });
 

--- a/src/allowance/allowance.service.ts
+++ b/src/allowance/allowance.service.ts
@@ -1,12 +1,26 @@
 import { Injectable } from '@nestjs/common';
-import { ConfigService } from '@nestjs/config';
+import { InjectRepository } from '@nestjs/typeorm';
+
+import { AllowanceHoldingsDTO } from '../dto/allowance-holdings.dto';
+import { AllowanceHoldingsParamsDTO } from '../dto/allowance-holdings.params.dto';
+import { AllowanceHoldingDimRepository } from './allowance-holding-dim.repository';
+import { AllowanceHoldingsMap } from '../maps/allowance-holdings.map';
 
 @Injectable()
 export class AllowanceService {
-  constructor(private configService: ConfigService) {}
+  constructor(
+    @InjectRepository(AllowanceHoldingDimRepository)
+    private readonly allowanceHoldingsRepository: AllowanceHoldingDimRepository,
+    private readonly allowanceHoldingsMap: AllowanceHoldingsMap,
+  ) {}
 
-  getAllowanceHoldings(): string {
-    return 'Hello allowanceHoldings';
+  async getAllowanceHoldings(
+    allowanceHoldingsParamsDTO: AllowanceHoldingsParamsDTO,
+  ): Promise<AllowanceHoldingsDTO[]> {
+    const query = await this.allowanceHoldingsRepository.getAllowanceHoldings(
+      allowanceHoldingsParamsDTO,
+    );
+    return this.allowanceHoldingsMap.many(query);
   }
 
   getAllowanceTransactions(): string {

--- a/src/dto/allowance-holdings.dto.ts
+++ b/src/dto/allowance-holdings.dto.ts
@@ -1,0 +1,14 @@
+export class AllowanceHoldingsDTO {
+  accountNumber: string;
+  accountName: string;
+  orisCode: number;
+  prgCode: string;
+  vintageYear: number;
+  totalBlock: number;
+  startBlock: number;
+  endBlock: number;
+  state: string;
+  epaRegion: number;
+  ownDisplay: string;
+  accountType: string;
+}

--- a/src/dto/allowance-holdings.params.dto.ts
+++ b/src/dto/allowance-holdings.params.dto.ts
@@ -1,0 +1,9 @@
+import { IsDefined } from 'class-validator';
+
+export class AllowanceHoldingsParamsDTO {
+  @IsDefined()
+  vintageBeginYear: number;
+
+  @IsDefined()
+  vintageEndYear: number;
+}

--- a/src/entities/account-fact.entity.ts
+++ b/src/entities/account-fact.entity.ts
@@ -1,0 +1,50 @@
+import { BaseEntity, Column, Entity, OneToMany, PrimaryColumn } from 'typeorm';
+
+import { AllowanceHoldingDim } from './allowance-holding-dim.entity';
+
+@Entity({ name: 'camddmw.account_fact' })
+export class AccountFact extends BaseEntity {
+  @PrimaryColumn({
+    name: 'account_number',
+  })
+  accountNumber: string;
+
+  @PrimaryColumn({
+    name: 'prg_code',
+  })
+  prgCode: string;
+
+  @Column({
+    name: 'account_name',
+  })
+  accountName: string;
+
+  @Column({
+    name: 'orispl_code',
+  })
+  orisCode: number;
+
+  @Column()
+  state: string;
+
+  @Column({
+    name: 'epa_region',
+  })
+  epaRegion: number;
+
+  @Column({
+    name: 'own_display',
+  })
+  ownDisplay: string;
+
+  @Column({
+    name: 'account_type',
+  })
+  accountType: string;
+
+  @OneToMany(
+    () => AllowanceHoldingDim,
+    ahd => ahd.accountFact,
+  )
+  allowanceHoldingDim: AllowanceHoldingDim[];
+}

--- a/src/entities/allowance-holding-dim.entity.ts
+++ b/src/entities/allowance-holding-dim.entity.ts
@@ -1,0 +1,64 @@
+import {
+  BaseEntity,
+  Column,
+  Entity,
+  JoinColumn,
+  ManyToOne,
+  PrimaryColumn,
+} from 'typeorm';
+
+import { AccountFact } from './account-fact.entity';
+
+@Entity({ name: 'camddmw.allowance_holding_dim' })
+export class AllowanceHoldingDim extends BaseEntity {
+  @PrimaryColumn({
+    name: 'vintage_year',
+  })
+  vintageYear: number;
+
+  @PrimaryColumn({
+    name: 'prg_code',
+  })
+  prgCode: string;
+
+  @PrimaryColumn({
+    name: 'start_block',
+  })
+  startBlock: number;
+
+  @Column({
+    name: 'account_number',
+  })
+  accountNumber: string;
+
+  @Column({
+    name: 'account_name',
+  })
+  accountName: string;
+
+  @Column({
+    name: 'total_block',
+  })
+  totalBlock: number;
+
+  @Column({
+    name: 'end_block',
+  })
+  endBlock: number;
+
+  @ManyToOne(
+    () => AccountFact,
+    af => af.allowanceHoldingDim,
+  )
+  @JoinColumn([
+    {
+      name: 'account_number',
+      referencedColumnName: 'accountNumber',
+    },
+    {
+      name: 'prg_code',
+      referencedColumnName: 'prgCode',
+    },
+  ])
+  accountFact: AccountFact;
+}

--- a/src/maps/allowance-holdings.map.ts
+++ b/src/maps/allowance-holdings.map.ts
@@ -1,0 +1,28 @@
+import { Injectable } from '@nestjs/common';
+
+import { BaseMap } from './base.map';
+import { AllowanceHoldingDim } from '../entities/allowance-holding-dim.entity';
+import { AllowanceHoldingsDTO } from '../dto/allowance-holdings.dto';
+
+@Injectable()
+export class AllowanceHoldingsMap extends BaseMap<
+  AllowanceHoldingDim,
+  AllowanceHoldingsDTO
+> {
+  public async one(entity: AllowanceHoldingDim): Promise<AllowanceHoldingsDTO> {
+    return {
+      accountNumber: entity.accountNumber,
+      accountName: entity.accountName,
+      orisCode: entity.accountFact.orisCode,
+      prgCode: entity.prgCode,
+      vintageYear: entity.vintageYear,
+      totalBlock: entity.totalBlock,
+      startBlock: entity.startBlock,
+      endBlock: entity.endBlock,
+      state: entity.accountFact.state,
+      epaRegion: entity.accountFact.epaRegion,
+      ownDisplay: entity.accountFact.ownDisplay,
+      accountType: entity.accountFact.accountType,
+    };
+  }
+}

--- a/src/maps/base.map.ts
+++ b/src/maps/base.map.ts
@@ -1,0 +1,7 @@
+export abstract class BaseMap<E, T> {
+  public abstract one(entity: E): Promise<T>;
+
+  public many(values: E[]): Promise<T[]> {
+    return Promise.all<T>(values.map(v => this.one(v)));
+  }
+}

--- a/src/utils/query-builder.helper.ts
+++ b/src/utils/query-builder.helper.ts
@@ -1,0 +1,22 @@
+export class QueryBuilderHelper {
+  public static createAllowanceQuery(
+    query: any,
+    dto: any,
+    param: string[],
+    allowanceAlias: string,
+    accountAlias: string,
+  ) {
+    if (param.includes('vintageBeginYear') && dto.vintageBeginYear) {
+      query.andWhere(`${allowanceAlias}.vintageYear >= :vintageBeginYear`, {
+        vintageBeginYear: dto.vintageBeginYear,
+      });
+    }
+
+    if (param.includes('vintageEndYear') && dto.vintageEndYear) {
+      query.andWhere(`${allowanceAlias}.vintageYear <= :vintageEndYear`, {
+        vintageEndYear: dto.vintageEndYear,
+      });
+    }
+    return query;
+  }
+}


### PR DESCRIPTION
## Pull Request

```
Added functionality to send required allowance holdings parameters (vintageBeginYear and vintageEndYear) to return allowance holdings data elements

- Added DTO and ParamsDTO
- Added entities (allowance_holding_dim and account_fact)
- Added BaseMap and AllowanceHoldingsMap
- Added QueryBuilderHelper class 
- Added Repository
- Modified module, service and controller to return allowance data
- Modified unit tests

```
